### PR TITLE
Install playwright first as it required for workarena-install

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,16 +81,15 @@ Run the following command to install WorkArena in the [BrowswerGym](https://gith
 pip install browsergym-workarena
 ```
 
-Then, run this command in a terminal to upload the benchmark data to your ServiceNow instance:
-```
-workarena-install
-```
-
-Finally, install [Playwright](https://github.com/microsoft/playwright):
+Then, install [Playwright](https://github.com/microsoft/playwright):
 ```
 playwright install
 ```
 
+Finally, run this command in a terminal to upload the benchmark data to your ServiceNow instance:
+```
+workarena-install
+```
 Your installation is now complete! 🎉
 
 


### PR DESCRIPTION
I have tried to install WorkArena as described in the readme on a MacOS and got the following error during `workarena-install` step:
```
playwright._impl._api_types.Error: Executable doesn't exist at /Users/ollmer/Library/Caches/ms-playwright/chromium-1084/chrome-mac/Chromium.app/Contents/MacOS/Chromium
╔════════════════════════════════════════════════════════════╗
║ Looks like Playwright was just installed or updated.       ║
║ Please run the following command to download new browsers: ║
║                                                            ║
║     playwright install                                     ║
║                                                            ║
║ <3 Playwright Team                                         ║
╚════════════════════════════════════════════════════════════╝
```
It looks like the order of the installation should be changed a little to work properly.