### PR TITLE
Check if workarena-install is correctly run

### DIFF
--- a/src/browsergym/workarena/api/utils.py
+++ b/src/browsergym/workarena/api/utils.py
@@ -172,3 +172,16 @@ def db_delete_from_table(instance: SNowInstance, sys_id: str, table: str) -> Non
 
     # Check for HTTP code 200 (fail otherwise)
     response.raise_for_status()
+
+
+def get_instance_sys_property(instance: SNowInstance, property_name: str) -> str:
+    """
+    Get a sys_property from the instance.
+    """
+    property_value = table_api_call(
+        instance=instance,
+        table="sys_properties",
+        params={"sysparm_query": f"name={property_name}", "sysparm_fields": "value"},
+    )["result"][0]["value"]
+
+    return property_value

--- a/src/browsergym/workarena/tasks/base.py
+++ b/src/browsergym/workarena/tasks/base.py
@@ -16,7 +16,7 @@ from urllib import parse
 
 from browsergym.core.task import AbstractBrowserTask
 from ..api.user import create_user
-from ..api.utils import table_api_call
+from ..api.utils import table_api_call, get_instance_sys_property
 from ..config import SNOW_BROWSER_TIMEOUT, SNOW_JS_UTILS_FILEPATH
 from ..utils import url_login
 from ..instance import SNowInstance
@@ -64,6 +64,17 @@ class AbstractServiceNowTask(AbstractBrowserTask, ABC):
         self.timeout = 10000  # ms
 
         self.instance = instance if instance is not None else SNowInstance()
+
+        # Check if workarena-install is done correctly
+        property_name = "workarena.installation.date"
+        try:
+            _ = get_instance_sys_property(self.instance, property_name)
+        except Exception:
+            raise RuntimeError(
+                f"ServiceNow instance is most likey not installed. "
+                "Please install the WorkArena plugin by running `workarena-install`.\n"
+            )
+
         self.start_url = self.instance.snow_url + start_rel_url
 
         if final_rel_url is not None:


### PR DESCRIPTION
Ensure that workarena-install is run before initializing any WorkArena task. It is not necessary to be run if the user just wants to explore the dev instance in an open-ended way.