### PR TITLE
Workarena/Base: Merge init scripts before evaluation.

### DIFF
--- a/src/browsergym/workarena/tasks/base.py
+++ b/src/browsergym/workarena/tasks/base.py
@@ -142,11 +142,19 @@ class AbstractServiceNowTask(AbstractBrowserTask, ABC):
         goal, info = self.setup_goal(page=page)
 
         # Load a few utility functions for init scripts
-        page.context.add_init_script(path=SNOW_JS_UTILS_FILEPATH)
+        with open(SNOW_JS_UTILS_FILEPATH, "r") as f:
+            utils_script = f.read()
 
-        # Add the initialization scripts to the page context
-        for script in self.get_init_scripts():
-            page.context.add_init_script(script)
+        # Merge all init scripts in a single file so they're guaranteed to be
+        # executed in order and in a shared context.
+        init_scripts =  [utils_script] + self.get_init_scripts()
+        init_script_js = "\n".join(init_scripts)
+        # Install initialization scripts in existing pages, and register them
+        # in the page context so that future pages will run them on creation.
+        page.context.add_init_script(init_script_js)
+        page.evaluate(init_script_js)
+        for f in page.frames:
+            f.evaluate(init_script_js)
 
         # Start the task if requested
         if do_start:

--- a/src/browsergym/workarena/tasks/base.py
+++ b/src/browsergym/workarena/tasks/base.py
@@ -152,9 +152,6 @@ class AbstractServiceNowTask(AbstractBrowserTask, ABC):
         # Install initialization scripts in existing pages, and register them
         # in the page context so that future pages will run them on creation.
         page.context.add_init_script(init_script_js)
-        page.evaluate(init_script_js)
-        for f in page.frames:
-            f.evaluate(init_script_js)
 
         # Start the task if requested
         if do_start:


### PR DESCRIPTION
Fixes #57 and duplicates without the need for downgrading the playwright version.

Playwright's init scripts are not executed sequentially, as per PW's docs:

<img width="979" height="175" alt="image" src="https://github.com/user-attachments/assets/1d9a9c9a-150f-40de-b4f7-6def953d7dc9" />

However, some benchmarks depend on all installed init scripts to be executed in order, which is why the page hangs if they don't (in WorkArena's case, this was because of the function being waited on being undefined - since the script defining it hadn't been evaluated yet).

It _shouldn't_ cause any problem to just concatenate all scripts together, so that we can guarantee FIFO execution order.