### PR TITLE
fix(api): check HTTP status before decoding POST responses

### DIFF
--- a/src/browsergym/workarena/api/utils.py
+++ b/src/browsergym/workarena/api/utils.py
@@ -62,13 +62,14 @@ def table_api_call(
         params=params,
         json=json,
     )
+
+    # Check for HTTP success code before decoding the response body.
+    response.raise_for_status()
+
     if method == "POST":
         sys_id = response.json()["result"]["sys_id"]
         data = {}
         params = {"sysparm_query": f"sys_id={sys_id}"}
-
-    # Check for HTTP success code (fail otherwise)
-    response.raise_for_status()
 
     record_exists = False
     num_retries = 0

--- a/tests/test_api_utils.py
+++ b/tests/test_api_utils.py
@@ -1,0 +1,66 @@
+import json
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+import requests
+
+from browsergym.workarena.api import utils
+
+
+@pytest.fixture
+def instance():
+    return SimpleNamespace(snow_url="https://example.invalid", snow_credentials=("user", "pass"))
+
+
+def make_response(status_code, content):
+    response = requests.Response()
+    response.status_code = status_code
+    response.url = "https://example.invalid/api/now/table/incident"
+    response._content = content
+    return response
+
+
+@pytest.mark.parametrize("method", ["GET", "POST", "PUT", "DELETE"])
+@pytest.mark.parametrize(
+    "status_code, content",
+    [(401, b'{"error": {"message": "Unauthorized"}}'), (503, b"<html>Unavailable</html>")],
+)
+def test_table_api_raises_http_error_before_decoding(
+    monkeypatch, instance, method, status_code, content
+):
+    response = make_response(status_code, content)
+    decode = Mock(wraps=response.json)
+    monkeypatch.setattr(response, "json", decode)
+    request = Mock(return_value=response)
+    sleep = Mock()
+    monkeypatch.setattr(utils.requests, "request", request)
+    monkeypatch.setattr(utils, "sleep", sleep)
+
+    with pytest.raises(requests.HTTPError) as exc_info:
+        utils.table_api_call(instance, table="incident", method=method)
+
+    assert exc_info.value.response is response
+    decode.assert_not_called()
+    sleep.assert_not_called()
+    assert request.call_count == 1
+
+
+def test_table_api_successful_post_still_waits_for_record(monkeypatch, instance):
+    created = {"result": {"sys_id": "record-123"}}
+    request = Mock(
+        side_effect=[
+            make_response(201, json.dumps(created).encode()),
+            make_response(200, b'{"result": [{"sys_id": "record-123"}]}'),
+        ]
+    )
+    monkeypatch.setattr(utils.requests, "request", request)
+    monkeypatch.setattr(utils, "sleep", Mock())
+
+    result = utils.table_api_call(instance, table="incident", method="POST")
+
+    assert result == created
+    assert request.call_count == 2
+    assert request.call_args_list[0].kwargs["method"] == "POST"
+    assert request.call_args_list[1].kwargs["method"] == "GET"
+    assert request.call_args_list[1].kwargs["params"] == {"sysparm_query": "sys_id=record-123"}


### PR DESCRIPTION
## Summary

Fixes #95.

Move `response.raise_for_status()` immediately after the Table API request, before the POST branch reads `response.json()["result"]["sys_id"]`.

Previously, a failed POST with a JSON error body raised `KeyError: 'result'`, and a failed POST with an HTML error page raised `JSONDecodeError`. Both masked the actual HTTP error. Successful POST polling and other method behavior are unchanged.

## Tests

Added offline tests using real `requests.Response` objects, a lightweight instance stand-in, and mocked HTTP calls/sleep:

- JSON 401 and HTML 503 responses for GET, POST, PUT, and DELETE preserve the original `HTTPError` response, without decoding or polling.
- A successful POST still polls for its created `sys_id` and returns the original creation response.

Before the fix: **2 failed, 7 passed** (the two POST error cases).
After the fix: **9 passed**.

```bash
PYTHONPATH=src uv run --no-project --python 3.12 \
  --with-requirements requirements.txt --with 'playwright==1.44.0' --with pytest -- \
  python -m pytest tests/test_api_utils.py -q
```

Black 24.10.0 and `git diff --check` pass. No browser was launched, no ServiceNow instance was contacted, and the live-instance integration suite was not run.

AI assistance: implemented and tested with OpenAI Codex.
